### PR TITLE
Inital pass at higher level VRP implementation

### DIFF
--- a/lib/or-tools.rb
+++ b/lib/or-tools.rb
@@ -22,6 +22,7 @@ require "or_tools/basic_scheduler"
 require "or_tools/seating"
 require "or_tools/sudoku"
 require "or_tools/tsp"
+require "or_tools/vrp"
 
 module ORTools
   class Error < StandardError; end

--- a/lib/or_tools/vrp.rb
+++ b/lib/or_tools/vrp.rb
@@ -1,6 +1,6 @@
 module ORTools
   class VRP
-    attr_reader :routes, :manager, :routing, :locations, :vehicle_count
+    attr_reader :manager, :routing, :locations, :vehicle_count
 
     DISTANCE_SCALE = 1
     DEGREES_TO_RADIANS = Math::PI / 180

--- a/lib/or_tools/vrp.rb
+++ b/lib/or_tools/vrp.rb
@@ -1,0 +1,66 @@
+module ORTools
+  class VRP
+    attr_reader :routes
+
+    DEGREES_TO_RADIANS = Math::PI / 180
+
+    def initialize(locations, vehicle_count, depot=0)
+      raise ArgumentError, "Locations must have latitude and longitude" unless locations.all? { |l| l[:latitude] && l[:longitude] }
+      raise ArgumentError, "Latitude must be between -90 and 90" unless locations.all? { |l| l[:latitude] >= -90 && l[:latitude] <= 90 }
+      raise ArgumentError, "Longitude must be between -180 and 180" unless locations.all? { |l| l[:longitude] >= -180 && l[:longitude] <= 180 }
+      raise ArgumentError, "Must be at least two locations" unless locations.size >= 2
+
+      distance_matrix =
+        locations.map do |from|
+          locations.map do |to|
+            # must be integers
+            (distance(from, to)).to_i
+          end
+        end
+
+      manager = ORTools::RoutingIndexManager.new(distance_matrix.length, vehicle_count, depot)
+      routing = ORTools::RoutingModel.new(manager)
+
+      distance_callback = lambda do |from_index, to_index|
+        from_node = manager.index_to_node(from_index)
+        to_node = manager.index_to_node(to_index)
+        distance_matrix[from_node][to_node]
+      end
+
+      transit_callback_index = routing.register_transit_callback(distance_callback)
+      routing.set_arc_cost_evaluator_of_all_vehicles(transit_callback_index)
+
+      # add a distance dimension
+      dimension_name = "Distance"
+      routing.add_dimension(transit_callback_index, 0, 3000, true, dimension_name)
+      distance_dimension = routing.mutable_dimension(dimension_name)
+      distance_dimension.global_span_cost_coefficient = 100
+
+      # run the solver
+      solution = routing.solve(first_solution_strategy: :path_cheapest_arc)
+
+      # calculate routes
+      @routes = []
+      vehicle_count.times do |vehicle_id|
+        route_indexes = []
+        index = routing.start(vehicle_id)
+        while !routing.end?(index)
+          route_indexes << manager.index_to_node(index)
+          previous_index = index
+          index = solution.value(routing.next_var(index))
+        end
+        @routes << locations.values_at(*route_indexes)
+      end
+    end
+
+    private
+
+    def distance(from, to)
+      from_lat = from[:latitude] * DEGREES_TO_RADIANS
+      from_lng = from[:longitude] * DEGREES_TO_RADIANS
+      to_lat = to[:latitude] * DEGREES_TO_RADIANS
+      to_lng = to[:longitude] * DEGREES_TO_RADIANS
+      2 * 6371 * Math.asin(Math.sqrt(Math.sin((to_lat - from_lat) / 2.0)**2 + Math.cos(from_lat) * Math.cos(to_lat) * Math.sin((from_lng - to_lng) / 2.0)**2))
+    end
+  end
+end

--- a/lib/or_tools/vrp.rb
+++ b/lib/or_tools/vrp.rb
@@ -1,7 +1,8 @@
 module ORTools
   class VRP
-    attr_reader :routes
+    attr_reader :routes, :manager, :routing, :locations, :vehicle_count
 
+    DISTANCE_SCALE = 1
     DEGREES_TO_RADIANS = Math::PI / 180
 
     def initialize(locations, vehicle_count, depot=0)
@@ -10,17 +11,14 @@ module ORTools
       raise ArgumentError, "Longitude must be between -180 and 180" unless locations.all? { |l| l[:longitude] >= -180 && l[:longitude] <= 180 }
       raise ArgumentError, "Must be at least two locations" unless locations.size >= 2
 
-      distance_matrix =
-        locations.map do |from|
-          locations.map do |to|
-            # must be integers
-            (distance(from, to)).to_i
-          end
-        end
+      @locations = locations
+      @vehicle_count = vehicle_count
 
-      manager = ORTools::RoutingIndexManager.new(distance_matrix.length, vehicle_count, depot)
-      routing = ORTools::RoutingModel.new(manager)
+      @manager = ORTools::RoutingIndexManager.new(distance_matrix.length, vehicle_count, depot)
+      @routing = ORTools::RoutingModel.new(manager)
+    end
 
+    def add_dimension(dimension_name, slack_max=0, capacity=3000, fix_start_cumulatve_to_zero=true) 
       distance_callback = lambda do |from_index, to_index|
         from_node = manager.index_to_node(from_index)
         to_node = manager.index_to_node(to_index)
@@ -30,17 +28,22 @@ module ORTools
       transit_callback_index = routing.register_transit_callback(distance_callback)
       routing.set_arc_cost_evaluator_of_all_vehicles(transit_callback_index)
 
-      # add a distance dimension
-      dimension_name = "Distance"
-      routing.add_dimension(transit_callback_index, 0, 3000, true, dimension_name)
+      # add a dimension
+      routing.add_dimension(
+        transit_callback_index,
+        slack_max,
+        (capacity / DISTANCE_SCALE).to_i,
+        fix_start_cumulatve_to_zero,
+        dimension_name
+      )
       distance_dimension = routing.mutable_dimension(dimension_name)
       distance_dimension.global_span_cost_coefficient = 100
+      return self
+    end
 
-      # run the solver
-      solution = routing.solve(first_solution_strategy: :path_cheapest_arc)
-
+    def routes
       # calculate routes
-      @routes = []
+      routes = []
       vehicle_count.times do |vehicle_id|
         route_indexes = []
         index = routing.start(vehicle_id)
@@ -49,8 +52,9 @@ module ORTools
           previous_index = index
           index = solution.value(routing.next_var(index))
         end
-        @routes << locations.values_at(*route_indexes)
+        routes << locations.values_at(*route_indexes)
       end
+      return routes
     end
 
     private
@@ -61,6 +65,20 @@ module ORTools
       to_lat = to[:latitude] * DEGREES_TO_RADIANS
       to_lng = to[:longitude] * DEGREES_TO_RADIANS
       2 * 6371 * Math.asin(Math.sqrt(Math.sin((to_lat - from_lat) / 2.0)**2 + Math.cos(from_lat) * Math.cos(to_lat) * Math.sin((from_lng - to_lng) / 2.0)**2))
+    end
+
+    def distance_matrix
+      @distance_matrix ||=
+        locations.map do |from|
+          locations.map do |to|
+            # must be integers
+            (distance(from, to) * DISTANCE_SCALE).to_i
+          end
+        end
+    end
+
+    def solution
+      @solution ||= routing.solve(first_solution_strategy: :path_cheapest_arc)
     end
   end
 end

--- a/test/vrp_test.rb
+++ b/test/vrp_test.rb
@@ -26,7 +26,7 @@ class VRPTest < Minitest::Test
       {:reference=>"HEETS01752", :latitude=>51.559565, :longitude=>-0.098628},
       {:reference=>"160620LON02D", :latitude=>51.523957, :longitude=>-0.127069}
     ]
-    vrp = ORTools::VRP.new(locations, 2)
+    vrp = ORTools::VRP.new(locations, 2).add_dimension("Distance")
     assert_equal 2, vrp.routes.count
   end
 end

--- a/test/vrp_test.rb
+++ b/test/vrp_test.rb
@@ -1,0 +1,33 @@
+require_relative "test_helper"
+
+class VRPTest < Minitest::Test
+  def test_works
+    locations = [
+      {:reference=>"HEETS01727", :latitude=>51.470462, :longitude=>-0.255665},
+      {:reference=>"HEETS01768", :latitude=>51.476025, :longitude=>-0.205112},
+      {:reference=>"160620LON01D", :latitude=>51.523957, :longitude=>-0.127069},
+      {:reference=>"HEETS01739", :latitude=>51.481615, :longitude=>-0.181795},
+      {:reference=>"160620LON02C", :latitude=>51.523957, :longitude=>-0.127069},
+      {:reference=>"HEETS01736", :latitude=>51.493276, :longitude=>-0.219917},
+      {:reference=>"HEETS01737", :latitude=>51.497367, :longitude=>-0.222679},
+      {:reference=>"HEETS01772", :latitude=>51.497363, :longitude=>-0.312997},
+      {:reference=>"PPE0004", :latitude=>51.514495, :longitude=>-0.135257},
+      {:reference=>"PPE0003", :latitude=>51.498691, :longitude=>-0.199912},
+      {:reference=>"HEETS01771", :latitude=>51.5275759, :longitude=>-0.3510861},
+      {:reference=>"HEETS01756", :latitude=>51.528199, :longitude=>-0.354785},
+      {:reference=>"PPE0005", :latitude=>51.5122015, :longitude=>-3.2797795},
+      {:reference=>"HEETS01747", :latitude=>51.634133, :longitude=>-0.102818},
+      {:reference=>"HEETS01757", :latitude=>51.559737, :longitude=>0.077569},
+      {:reference=>"HEETS01725", :latitude=>51.571479, :longitude=>0.134208},
+      {:reference=>"HEETS01763", :latitude=>51.581164, :longitude=>0.021524},
+      {:reference=>"HEETS01764", :latitude=>51.562728, :longitude=>0.090968},
+      {:reference=>"HEETS01734", :latitude=>51.590121, :longitude=>-0.024429},
+      {:reference=>"HEETS01721", :latitude=>51.566335, :longitude=>0.000885},
+      {:reference=>"HEETS01752", :latitude=>51.559565, :longitude=>-0.098628},
+      {:reference=>"160620LON02D", :latitude=>51.523957, :longitude=>-0.127069}
+    ]
+    vrp = ORTools::VRP.new(locations, 2)
+    assert_equal 2, vrp.routes.count
+  end
+end
+


### PR DESCRIPTION
Accepts a list of locations and the number of vehicles in use and
calculates the appropriate number of routes.

## Issues
With the location data supplied in `test/vrp_test.rb`, if I calculate
the distance matrix and scale distances with `DISTANCE_SCALE` the
program segfaults (note, the sample locations data is "real world"
and represents several locations broadly within one city). If I use the
locations data from `test/tsp_test.rb` _without_ scaling distances, the
program segfaults. Seems that there is a point at which is makes sense
to scale distances, but until that point is reached doing so causes
problems. I wonder if the `DISTANCE_SCALE` should be either dynamic
based on the distances between the points being routed, or user
configurable?

## Refactorings
I've basically duplicated the distance matrix calculation from the TSP
solution. Could this be extracted into it's own class?

Similarly, right now TSP returns an instance of itself with four
`attr_accessor`s: `route`, `route_indexes`, `distances`,
`total_distance`. VRP currently simply returns an instance of itself
with the attr_accessor `routes`, which is an array of arrays containing
the routed locations. I feel like it would be cool if there were a
`Route` class that would tie up `route`, `route_indexes`, `distances`
and `total_distance`. TSP would then return a simple instance of the
`Route` class, VRP would return an array of `Route` classes. wdyt?

This is a real basic first pass. Please let me know if there are any
changes that should be made at this stage.

:v: