### PR TITLE
Add solution_info to CpSolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.1 (unreleased)
+- Added `solution_info` to `CpSolver`
+
 ## 0.9.0 (2022-12-02)
 
 - Updated OR-Tools to 9.5

--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -371,6 +371,11 @@ void init_constraint(Rice::Module& m) {
         }
       })
     .define_method(
+      "solution_info",
+      [](CpSolverResponse& self) {
+        return self.solution_info();
+      })
+    .define_method(
       "sufficient_assumptions_for_infeasibility",
       [](CpSolverResponse& self) {
         auto a = Array();

--- a/lib/or_tools/cp_solver.rb
+++ b/lib/or_tools/cp_solver.rb
@@ -41,6 +41,10 @@ module ORTools
       end
     end
 
+    def solution_info
+      @response.solution_info
+    end
+
     def sufficient_assumptions_for_infeasibility
       @response.sufficient_assumptions_for_infeasibility
     end

--- a/test/solution_info_sat_test.rb
+++ b/test/solution_info_sat_test.rb
@@ -1,0 +1,18 @@
+require_relative "test_helper"
+
+class SolutionInfoSat < Minitest::Test
+  def test_solution_info_sat
+    model = ORTools::CpModel.new
+
+    x = model.new_int_var(0, 10, 'x')
+    y = model.new_int_var(0, 10, 'y')
+    z = model.new_int_var(0, 10, 'z')
+
+    model.add_division_equality(x, y, z)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :model_invalid, status
+    assert_match /^The divisor cannot span across zero/, solver.solution_info
+  end
+end


### PR DESCRIPTION
Hi @ankane, I'm not sure about this PR, but I figured that I'd open it to get your feedback.

I was playing around with division in the CP-SAT solver, and I ran into a problem where I got back a `model_invalid` status from the solver.

The docs suggest multiple things for debugging this, such as [calling `ValidateCpModel(model_proto)`](https://developers.google.com/optimization/cp/cp_solver#cp-sat_return_values) for C++ or [`model.Validate()`](https://developers.google.com/optimization/reference/python/sat/python/cp_model#validate) for python.

Less documented, however, is [the `solution_info` attribute in the `CpSolverResponse` proto](https://github.com/google/or-tools/blob/8179abf8346b02c9aa39d356177fdbd6315f2c34/ortools/sat/cp_model.proto#L812), which `SolveCpModel` [sets with an error message](https://github.com/google/or-tools/blob/8179abf8346b02c9aa39d356177fdbd6315f2c34/ortools/sat/cp_model_solver.cc#L3363) if there is one while doing validation before solving.

To debug my problem locally, I ultimately took this `solution_info` path. And I was curious about your thoughts on it. I'm not sure if we want to go down the path of exposing `CpSolverResponse.solution_info()` when to my casual reading it seems less documented compared to `ValidateCpModel(model_proto)`. But I thought I'd offer this up here to start a discussion.