### PR TITLE
Add way to get upper and lower bounds of `SatIntVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1 (2023-03-17)
+
+- Add way to get upper and lower bounds of `SatIntVar`
+
 ## 0.10.0 (2023-03-15)
 
 - Updated OR-Tools to 9.6

--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -3,6 +3,7 @@
 
 #include "ext.h"
 
+using operations_research::Domain;
 using operations_research::sat::BoolVar;
 using operations_research::sat::Constraint;
 using operations_research::sat::CpModelBuilder;
@@ -98,8 +99,13 @@ namespace Rice::detail
 }
 
 void init_constraint(Rice::Module& m) {
+  Rice::define_class_under<Domain>(m, "Domain")
+    .define_method("min", &Domain::Min)
+    .define_method("max", &Domain::Max);
+
   rb_cSatIntVar = Rice::define_class_under<IntVar>(m, "SatIntVar")
-    .define_method("name", &IntVar::Name);
+    .define_method("name", &IntVar::Name)
+    .define_method("domain", &IntVar::Domain);
 
   Rice::define_class_under<IntervalVar>(m, "SatIntervalVar")
     .define_method("name", &IntervalVar::Name);

--- a/test/constraint_test.rb
+++ b/test/constraint_test.rb
@@ -234,6 +234,17 @@ class ConstraintTest < Minitest::Test
     end
   end
 
+  def test_int_var_domain
+    model = ORTools::CpModel.new
+
+    lower_bound = (0..9).to_a.sample
+    upper_bound = (10..19).to_a.sample
+    x = model.new_int_var(lower_bound, upper_bound, "x")
+
+    assert_equal lower_bound, x.domain.min
+    assert_equal upper_bound, x.domain.max
+  end
+
   def test_sum_empty_true
     model = ORTools::CpModel.new
     model.add([].sum < 2)


### PR DESCRIPTION
### TL;DR

Hi @ankane, I'm looking for a way to get the upper bound of a `SatIntVar`, and so I've put together a solution for your review 🙏 I've taken the most "true to or-tools" approach to modeling things, but I could see the argument for alternative ways of modeling things.

### The problem I'm trying to solve

The business problem I'm looking to solve seeks to minimize several different variables at once. There's a strict hierarchy to these variables -- each one is infinitely more important than the next. So sort of like how one might sort a spreadsheet by column A, then column B, etc, the minutest difference in variable A "overpowers" the most massive differences in variable B.

If I had three variables (`c`, `b`, `a`, listed in increasing order of importance) that all had a range of 0-99, I could've implemented my cost function like so:
```rb
model.minimize(
  model.sum([
    c,
    b * (10 ** 2),
    a * (10 ** 4)
  ])
)
```

But in the business problem I'm trying to solve, my variables actually have **_dynamic_** ranges, so I'm looking to implement my cost function like so:
```rb
model.minimize(
  model.sum([
    c,
    b * (10 ** c.upper_bound.digits.count),
    a * (10 ** (c.upper_bound.digits.count + b.upper_bound.digits.count))
  ])
)
```
In this example, `upper_bound` is a method that doesn't exist.

### A solution

I looked through the or-tools C++ source code, and I noticed that the sat `IntVar` [has a `Domain` member](https://github.com/or-tools/or-tools/blob/92eab40155d5566039c92662632f196174f8da47/ortools/sat/cp_model.cc#L134-L137) which returns a `Domain` type, and this `Domain` type [has `Min` and `Max` members](https://github.com/or-tools/or-tools/blob/92eab40155d5566039c92662632f196174f8da47/ortools/constraint_solver/expressions.cc#L1338-L1340) which are the lower and upper bounds that the sat `IntVar` is initialized with. (Or at least that's my understanding of the code, I've only recently began to learn C++.)

In this PR, I've implemented things exactly like they are in or-tools -- I've added a `#domain` method to the `SatIntVar` class, which returns a new `Domain` class, which exposes `#min` and `#max` methods.

### Alternative solutions

However, I could see the argument for an alternative approach where we skip the intermediate `Domain` class, and we expose some methods directly on the `SatIntVar` class, such as `#lower_bound` and `#upper_bound`.

Also, I could see the argument that this PR is entirely unnecessary, and that I could just separately keep track of the upper bound for each variable I'm using (e.g. in addition to variable `a`, and I define an `a_upper_bound` variable.)