### PR TITLE
Readme: Call solver in bin packing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1607,6 +1607,8 @@ end
 solver.minimize(data[:bins].sum { |j| y[j] })
 
 # call the solver and print the solution
+status = solver.solve
+
 if status == :optimal
   num_bins = 0
   data[:bins].each do |j|


### PR DESCRIPTION
When trying out some examples I noticed that this one didn't work immediately, `status` wasn't available, since the `solver.solve` call was missing (example code style as in example above)