### PR TITLE
Add int_var_with_integer_list_domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.lock
 *.bundle
 *.so
+.tool-versions
+.vscode/settings.json

--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -102,7 +102,12 @@ void init_constraint(Rice::Module& m) {
   Rice::define_class_under<Domain>(m, "Domain")
     .define_constructor(Rice::Constructor<Domain, int64_t, int64_t>())
     .define_method("min", &Domain::Min)
-    .define_method("max", &Domain::Max);
+    .define_method("max", &Domain::Max)
+    .define_method("size", &Domain::Size)
+    .define_method("contains", 
+      [](Domain& self, int32_t value) {
+        return self.Contains(value);
+      });
 
   rb_cSatIntVar = Rice::define_class_under<IntVar>(m, "SatIntVar")
     .define_method("name", &IntVar::Name)
@@ -169,6 +174,11 @@ void init_constraint(Rice::Module& m) {
       [](CpModelBuilder& self, int64_t start, int64_t end, const std::string& name) {
         const operations_research::Domain domain(start, end);
         return self.NewIntVar(domain).WithName(name);
+      })
+    .define_method(
+      "new_int_var_with_integer_list_domain",
+      [](CpModelBuilder& self, std::vector<int64_t> values, const std::string& name) {
+        return self.NewIntVar(Domain::FromValues(values)).WithName(name);
       })
     .define_method(
       "new_bool_var",

--- a/test/constraint_test.rb
+++ b/test/constraint_test.rb
@@ -245,6 +245,17 @@ class ConstraintTest < Minitest::Test
     assert_equal upper_bound, x.domain.max
   end
 
+  def test_new_int_var_with_integer_list_domain
+    model = ORTools::CpModel.new
+
+    x = model.new_int_var_with_integer_list_domain([5,0,1,5], "x")
+
+    assert_equal 0, x.domain.min
+    assert_equal 5, x.domain.max
+    assert_equal 3, x.domain.size
+    assert x.domain.contains(1)
+  end
+
   def test_sum_empty_true
     model = ORTools::CpModel.new
     model.add([].sum < 2)


### PR DESCRIPTION
Adds the ability to define an int var with a list of integers as a domain. Don't love the long method name, and maybe we could use overloading?