### PR TITLE
Add RICE binding for definition of a domain from values

### DIFF
--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -70,6 +70,7 @@ namespace Rice::detail
 void init_constraint(Rice::Module& m) {
   Rice::define_class_under<Domain>(m, "Domain")
     .define_constructor(Rice::Constructor<Domain, int64_t, int64_t>())
+    .define_function("from_values", &Domain::FromValues)
     .define_method("min", &Domain::Min)
     .define_method("max", &Domain::Max);
 


### PR DESCRIPTION
Hello,

When trying to use this library for a project (thank you by the way!) I was missing this function (it creates a domain from a list of distinct values instead of a range) that was available in my Python POC.

Adding this line was enough to have it working on my side, let me know if it's enough to add the function upstream too.