### PR TITLE
Add name to MPVariable binding for inspect and printing

### DIFF
--- a/ext/or-tools/math_opt.cpp
+++ b/ext/or-tools/math_opt.cpp
@@ -64,6 +64,7 @@ void init_math_opt(Rice::Module& m) {
 
   Rice::define_class_under<Variable>(mathopt, "Variable")
     .define_method("id", &Variable::id)
+    .define_method("name", &Variable::name)
     .define_method(
       "_eql?",
       [](Variable& self, Variable &other) {

--- a/test/math_opt_test.rb
+++ b/test/math_opt_test.rb
@@ -74,4 +74,11 @@ class MathOptTest < Minitest::Test
     end
     assert_equal "Glop does not support integer variables", error.message
   end
+
+  def test_variable_inspect
+    model = ORTools::MathOpt::Model.new("getting_started_lp")
+    var = model.add_integer_variable(-1.0, 1.5, "x")
+
+    assert_equal "x", var.inspect
+  end
 end


### PR DESCRIPTION
Thanks for creating and maintaining the gem.

The changes add the `name` field of the `MPVariable` class to the binding, allowing the inspect method to work how they do for the other variable classes. This is currently broken.