### PR TITLE
Linear solver parameters

### DIFF
--- a/ext/or-tools/linear.cpp
+++ b/ext/or-tools/linear.cpp
@@ -60,7 +60,38 @@ void init_linear(Rice::Module& m) {
     .define_method("set_minimization", &MPObjective::SetMinimization);
 
   Rice::define_class_under<MPSolverParameters>(m, "MPSolverParameters")
-    .define_constructor(Rice::Constructor<MPSolverParameters>());
+    .define_constructor(Rice::Constructor<MPSolverParameters>())
+    .define_method("reset", &MPSolverParameters::Reset)
+    .define_method(
+      "relative_mip_gap=",
+      [](MPSolverParameters& self, double relative_mip_gap) {
+        self.SetDoubleParam(MPSolverParameters::DoubleParam::RELATIVE_MIP_GAP, relative_mip_gap);
+      })
+    .define_method(
+      "relative_mip_gap",
+      [](MPSolverParameters& self) {
+        return self.GetDoubleParam(MPSolverParameters::DoubleParam::RELATIVE_MIP_GAP);
+      })
+    .define_method(
+      "primal_tolerance=",
+      [](MPSolverParameters& self, double primal_tolerance) {
+        self.SetDoubleParam(MPSolverParameters::DoubleParam::PRIMAL_TOLERANCE, primal_tolerance);
+      })
+    .define_method(
+      "primal_tolerance",
+      [](MPSolverParameters& self) {
+        return self.GetDoubleParam(MPSolverParameters::DoubleParam::PRIMAL_TOLERANCE);
+      })
+    .define_method(
+      "dual_tolerance=",
+      [](MPSolverParameters& self, double dual_tolerance) {
+        self.SetDoubleParam(MPSolverParameters::DoubleParam::DUAL_TOLERANCE, dual_tolerance);
+      })
+    .define_method(
+      "dual_tolerance",
+      [](MPSolverParameters& self) {
+        return self.GetDoubleParam(MPSolverParameters::DoubleParam::DUAL_TOLERANCE);
+      });
 
   Rice::define_class_under<MPSolver>(m, "Solver")
     .define_singleton_function(

--- a/ext/or-tools/linear.cpp
+++ b/ext/or-tools/linear.cpp
@@ -57,6 +57,7 @@ void init_linear(Rice::Module& m) {
     .define_method("set_coefficient", &MPObjective::SetCoefficient)
     .define_method("set_offset", &MPObjective::SetOffset)
     .define_method("set_maximization", &MPObjective::SetMaximization)
+    .define_method("best_bound", &MPObjective::BestBound)
     .define_method("set_minimization", &MPObjective::SetMinimization);
 
   Rice::define_class_under<MPSolverParameters>(m, "MPSolverParameters")

--- a/ext/or-tools/linear.cpp
+++ b/ext/or-tools/linear.cpp
@@ -4,6 +4,7 @@
 
 using operations_research::MPConstraint;
 using operations_research::MPObjective;
+using operations_research::MPSolverParameters;
 using operations_research::MPSolver;
 using operations_research::MPVariable;
 
@@ -58,6 +59,9 @@ void init_linear(Rice::Module& m) {
     .define_method("set_maximization", &MPObjective::SetMaximization)
     .define_method("set_minimization", &MPObjective::SetMinimization);
 
+  Rice::define_class_under<MPSolverParameters>(m, "MPSolverParameters")
+    .define_constructor(Rice::Constructor<MPSolverParameters>());
+
   Rice::define_class_under<MPSolver>(m, "Solver")
     .define_singleton_function(
       "_new",
@@ -109,9 +113,9 @@ void init_linear(Rice::Module& m) {
         return self.MakeRowConstraint(lb, ub);
       })
     .define_method(
-      "solve",
-      [](MPSolver& self) {
-        auto status = self.Solve();
+      "_solve",
+      [](MPSolver& self, MPSolverParameters& params) {
+        auto status = self.Solve(params);
 
         if (status == MPSolver::ResultStatus::OPTIMAL) {
           return Symbol("optimal");

--- a/lib/or_tools/solver.rb
+++ b/lib/or_tools/solver.rb
@@ -34,6 +34,14 @@ module ORTools
       objective.set_minimization
     end
 
+    def solve
+      _solve(parameters)
+    end
+
+    def parameters
+      @parameters ||= MPSolverParameters.new
+    end
+
     private
 
     def set_objective(expr)

--- a/test/linear_test.rb
+++ b/test/linear_test.rb
@@ -96,4 +96,25 @@ class LinearTest < Minitest::Test
     end
     assert_equal "Unrecognized solver type", error.message
   end
+
+  def test_relative_mip_gap_parameter
+    params = ORTools::MPSolverParameters.new
+
+    params.relative_mip_gap = 42
+    assert_equal 42, params.relative_mip_gap
+  end
+
+  def test_primal_tolerance_parameter
+    params = ORTools::MPSolverParameters.new
+
+    params.primal_tolerance = 42
+    assert_equal 42, params.primal_tolerance
+  end
+
+  def test_dual_tolerance_parameter
+    params = ORTools::MPSolverParameters.new
+
+    params.dual_tolerance = 42
+    assert_equal 42, params.dual_tolerance
+  end
 end


### PR DESCRIPTION
Thanks for creating and maintaining the gem.

Added the bindings for `MPSolverParameters` to pass parameters for `relative_mip_gap`, `primal_tolerance`, and `dual_tolerance`. With regard to usage, I followed the style of the `CpSolver`. Also added the access to the `best_bound` field to be able to access the mip gap.