### PR TITLE
Implement From_Ruby#is_convertible methods

### DIFF
--- a/ext/or-tools/bin_packing.cpp
+++ b/ext/or-tools/bin_packing.cpp
@@ -23,6 +23,18 @@ namespace Rice::detail
   class From_Ruby<KnapsackSolver::SolverType>
   {
   public:
+    Convertible is_convertible(VALUE value)
+    {
+      switch (rb_type(value))
+      {
+        case RUBY_T_DATA:
+          return Data_Type<KnapsackSolver::SolverType>::is_descendant(value) ? Convertible::Exact : Convertible::None;
+          break;
+        default:
+          return Convertible::None;
+      }
+    }
+
     KnapsackSolver::SolverType convert(VALUE x)
     {
       auto s = Symbol(x).str();

--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -42,6 +42,18 @@ namespace Rice::detail
   class From_Ruby<LinearExpr>
   {
   public:
+    Convertible is_convertible(VALUE value)
+    {
+      switch (rb_type(value))
+      {
+        case RUBY_T_DATA:
+          return Data_Type<LinearExpr>::is_descendant(value) ? Convertible::Exact : Convertible::None;
+          break;
+        default:
+          return Convertible::None;
+      }
+    }
+
     LinearExpr convert(VALUE v)
     {
       LinearExpr expr;

--- a/ext/or-tools/linear.cpp
+++ b/ext/or-tools/linear.cpp
@@ -29,6 +29,18 @@ namespace Rice::detail
   template<>
   struct From_Ruby<MPSolver::OptimizationProblemType>
   {
+    Convertible is_convertible(VALUE value)
+    {
+      switch (rb_type(value))
+      {
+      case RUBY_T_DATA:
+        return Data_Type<MPSolver::OptimizationProblemType>::is_descendant(value) ? Convertible::Exact : Convertible::None;
+        break;
+      default:
+        return Convertible::None;
+      }
+    }
+
     static MPSolver::OptimizationProblemType convert(VALUE x)
     {
       auto s = Symbol(x).str();

--- a/ext/or-tools/math_opt.cpp
+++ b/ext/or-tools/math_opt.cpp
@@ -29,6 +29,18 @@ namespace Rice::detail
   template<>
   struct From_Ruby<SolverType>
   {
+    Convertible is_convertible(VALUE value)
+    {
+      switch (rb_type(value))
+      {
+      case RUBY_T_DATA:
+        return Data_Type<SolverType>::is_descendant(value) ? Convertible::Exact : Convertible::None;
+        break;
+      default:
+        return Convertible::None;
+      }
+    }
+
     static SolverType convert(VALUE x)
     {
       auto s = Symbol(x).str();

--- a/ext/or-tools/routing.cpp
+++ b/ext/or-tools/routing.cpp
@@ -38,6 +38,18 @@ namespace Rice::detail
   class From_Ruby<RoutingNodeIndex>
   {
   public:
+    Convertible is_convertible(VALUE value)
+    {
+      switch (rb_type(value))
+      {
+      case RUBY_T_DATA:
+        return Data_Type<RoutingNodeIndex>::is_descendant(value) ? Convertible::Exact : Convertible::None;
+        break;
+      default:
+        return Convertible::None;
+      }
+    }
+
     RoutingNodeIndex convert(VALUE x)
     {
       const RoutingNodeIndex index{From_Ruby<int>().convert(x)};


### PR DESCRIPTION
Fixes for latest Rice master. The #is_convertible method is now required. Note it now returns an Enum and not a boolean, but since you did not have these methods before they were not being compiled. IE, should work with released Rice (they just won't do anything).