### PR TITLE
Release gvl and add more constraint types

### DIFF
--- a/test/constraint_test.rb
+++ b/test/constraint_test.rb
@@ -289,6 +289,324 @@ class ConstraintTest < Minitest::Test
     assert_equal 3, domain.max
   end
 
+  def test_bool_cardinality_constraints
+    model = ORTools::CpModel.new
+    a = model.new_bool_var("a")
+    b = model.new_bool_var("b")
+    c = model.new_bool_var("c")
+
+    model.add_at_least_one([a, b])
+    model.add_at_most_one([a, b])
+    model.add_exactly_one([b, c])
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+
+    a_val = solver.value(a) ? 1 : 0
+    b_val = solver.value(b) ? 1 : 0
+    c_val = solver.value(c) ? 1 : 0
+
+    assert_equal 1, a_val + b_val
+    assert_equal 1, b_val + c_val
+  end
+
+  def test_element_constraints
+    model = ORTools::CpModel.new
+    index = model.new_int_var(0, 2, "index")
+    model.add(index == 2)
+
+    const_target = model.new_int_var(0, 10, "const_target")
+    model.add_element(index, [3, 5, 7], const_target)
+
+    v0 = model.new_int_var(0, 30, "v0")
+    v1 = model.new_int_var(0, 30, "v1")
+    v2 = model.new_int_var(0, 30, "v2")
+    model.add(v0 == 10)
+    model.add(v1 == 20)
+    model.add(v2 == 30)
+
+    var_target = model.new_int_var(0, 40, "var_target")
+    model.add_variable_element(index, [v0, v1, v2], var_target)
+
+    expr_target = model.new_int_var(0, 50, "expr_target")
+    exprs = [v0 + 1, v1 + 1, v2 + 1]
+    model.add_element(index, exprs, expr_target)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal 7, solver.value(const_target)
+    assert_equal 30, solver.value(var_target)
+    assert_equal 31, solver.value(expr_target)
+  end
+
+  def test_circuit_constraint
+    model = ORTools::CpModel.new
+    arcs = [[0, 1], [1, 2], [2, 0], [0, 2], [2, 1], [1, 0]]
+    literals = arcs.map { |tail, head| model.new_bool_var("arc_#{tail}_#{head}") }
+
+    circuit = model.add_circuit_constraint
+    arcs.each_with_index do |(tail, head), idx|
+      circuit.add_arc(tail, head, literals[idx])
+    end
+
+    required = [[0, 1], [1, 2], [2, 0]]
+    arcs.each_with_index do |arc, idx|
+      if required.include?(arc)
+        model.add(literals[idx] == 1)
+      else
+        model.add(literals[idx] == 0)
+      end
+    end
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    required.each do |arc|
+      lit = literals[arcs.index(arc)]
+      assert_equal true, solver.value(lit)
+    end
+  end
+
+  def test_multiple_circuit_constraint_multiple_tours
+    model = ORTools::CpModel.new
+    arcs = [
+      [0, 1], [1, 0],
+      [0, 2], [2, 0],
+      [0, 3], [3, 0],
+      [1, 2], [2, 1], [1, 3], [3, 1], [2, 3], [3, 2],
+      [3, 3],
+      [4, 4]
+    ]
+    literals = arcs.map { |tail, head| model.new_bool_var("route_#{tail}_#{head}") }
+
+    routes = model.add_multiple_circuit_constraint
+    arcs.each_with_index do |(tail, head), idx|
+      routes.add_arc(tail, head, literals[idx])
+    end
+
+    # Force two short depot tours: 0->1->0 and 0->2->0. Node 3 should stay unused and loop,
+    # node 4 is entirely optional via self-loop.
+    must_have = [[0, 1], [1, 0], [0, 2], [2, 0], [3, 3], [4, 4]]
+    arcs.each_with_index do |arc, idx|
+      if must_have.include?(arc)
+        model.add(literals[idx] == 1)
+      else
+        model.add(literals[idx] == 0)
+      end
+    end
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal true, solver.value(literals[arcs.index([3, 3])])
+  end
+
+  def test_circuit_constraint_with_optional_node
+    model = ORTools::CpModel.new
+    arcs = [
+      [0, 1], [1, 2], [2, 0],
+      [3, 3]
+    ]
+    literals = arcs.map { |tail, head| model.new_bool_var("arc_#{tail}_#{head}") }
+
+    circuit = model.add_circuit_constraint
+    arcs.each_with_index do |(tail, head), idx|
+      circuit.add_arc(tail, head, literals[idx])
+    end
+
+    required = [[0, 1], [1, 2], [2, 0]]
+    arcs.each_with_index do |arc, idx|
+      model.add(literals[idx] == 1) if required.include?(arc)
+    end
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+
+    loop_literal = literals[arcs.index([3, 3])]
+    assert_equal true, solver.value(loop_literal)
+  end
+
+  def test_multiple_circuit_constraint
+    model = ORTools::CpModel.new
+    arcs = [
+      [0, 1], [1, 2], [2, 0],
+      [0, 2], [2, 1], [1, 0]
+    ]
+    literals = arcs.map { |tail, head| model.new_bool_var("route_#{tail}_#{head}") }
+
+    routes = model.add_multiple_circuit_constraint
+    arcs.each_with_index do |(tail, head), idx|
+      routes.add_arc(tail, head, literals[idx])
+    end
+
+    required = [[0, 1], [1, 2], [2, 0]]
+    arcs.each_with_index do |arc, idx|
+      if required.include?(arc)
+        model.add(literals[idx] == 1)
+      else
+        model.add(literals[idx] == 0)
+      end
+    end
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    required.each do |arc|
+      lit = literals[arcs.index(arc)]
+      assert_equal true, solver.value(lit)
+    end
+  end
+
+  def test_reservoir_constraint_with_optional_event
+    model = ORTools::CpModel.new
+    reservoir = model.add_reservoir_constraint(0, 3)
+
+    first_fill_time = model.new_int_var(0, 0, "first_fill")
+    reservoir.add_event(first_fill_time, 2)
+
+    drain_time = model.new_int_var(1, 1, "drain_time")
+    optional = model.new_bool_var("drain_required")
+    reservoir.add_optional_event(drain_time, -1, optional)
+
+    second_fill_time = model.new_int_var(2, 2, "second_fill")
+    reservoir.add_event(second_fill_time, 2)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal true, solver.value(optional)
+  end
+
+
+  def test_cumulative_constraint_with_optional_interval
+    model = ORTools::CpModel.new
+    capacity = model.new_constant(3)
+    cumulative = model.add_cumulative(capacity)
+
+    start1 = model.new_int_var(0, 0, "start1")
+    interval1 = model.new_fixed_size_interval_var(start1, 1, "task1")
+    cumulative.add_demand(interval1, 2)
+
+    start2 = model.new_int_var(0, 1, "start2")
+    interval2 = model.new_fixed_size_interval_var(start2, 2, "task2")
+    cumulative.add_demand(interval2, 2)
+
+    presence = model.new_bool_var("task3_presence")
+    model.add(presence == 1)
+    start3 = model.new_int_var(1, 1, "start3")
+    interval3 = model.new_optional_fixed_size_interval_var(start3, 1, presence, "task3")
+    cumulative.add_demand(interval3, 1)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal 1, solver.value(start2)
+    assert_equal true, solver.value(presence)
+  end
+
+  def test_cumulative_constraint_drops_optional_job
+    model = ORTools::CpModel.new
+    capacity = model.new_constant(3)
+    cumulative = model.add_cumulative(capacity)
+
+    start1 = model.new_int_var(0, 0, "base_start")
+    interval1 = model.new_fixed_size_interval_var(start1, 2, "base_task")
+    cumulative.add_demand(interval1, 2)
+
+    start2 = model.new_int_var(2, 2, "base_start_2")
+    interval2 = model.new_fixed_size_interval_var(start2, 2, "base_task_2")
+    cumulative.add_demand(interval2, 2)
+
+    optional_presence = model.new_bool_var("optional_presence")
+    optional_start = model.new_int_var(0, 0, "optional_start")
+    optional_interval = model.new_optional_fixed_size_interval_var(optional_start, 1, optional_presence, "optional_task")
+    cumulative.add_demand(optional_interval, 2)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal false, solver.value(optional_presence)
+  end
+
+  def test_no_overlap_2d_constraint
+    model = ORTools::CpModel.new
+
+    x1_start = model.new_int_var(0, 0, "x1_start")
+    y1_start = model.new_int_var(0, 0, "y1_start")
+    rect1_x = model.new_fixed_size_interval_var(x1_start, 2, "rect1_x")
+    rect1_y = model.new_fixed_size_interval_var(y1_start, 2, "rect1_y")
+
+    x2_start = model.new_int_var(0, 2, "x2_start")
+    y2_start = model.new_int_var(0, 0, "y2_start")
+    rect2_x = model.new_fixed_size_interval_var(x2_start, 2, "rect2_x")
+    rect2_y = model.new_fixed_size_interval_var(y2_start, 2, "rect2_y")
+
+    constraint = model.add_no_overlap_2d
+    constraint.add_rectangle(rect1_x, rect1_y)
+    constraint.add_rectangle(rect2_x, rect2_y)
+
+    model.minimize(x2_start)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal 2, solver.value(x2_start)
+  end
+
+  def test_no_overlap_2d_optional_rectangles
+    model = ORTools::CpModel.new
+
+    base_x = model.new_int_var(0, 0, "base_x")
+    base_y = model.new_int_var(0, 0, "base_y")
+    base_rect_x = model.new_fixed_size_interval_var(base_x, 2, "base_rect_x")
+    base_rect_y = model.new_fixed_size_interval_var(base_y, 2, "base_rect_y")
+
+    optional_start_x = model.new_int_var(0, 4, "opt_x")
+    optional_start_y = model.new_int_var(0, 0, "opt_y")
+    opt_presence = model.new_bool_var("opt_present")
+    opt_rect_x = model.new_optional_fixed_size_interval_var(optional_start_x, 2, opt_presence, "opt_rect_x")
+    opt_rect_y = model.new_optional_fixed_size_interval_var(optional_start_y, 2, opt_presence, "opt_rect_y")
+
+    constraint = model.add_no_overlap_2d
+    constraint.add_rectangle(base_rect_x, base_rect_y)
+    constraint.add_rectangle(opt_rect_x, opt_rect_y)
+
+    model.maximize(opt_presence * 10 - optional_start_x)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal true, solver.value(opt_presence)
+    assert_equal 2, solver.value(optional_start_x)
+  end
+
+  def test_min_max_and_multiplication_equalities
+    model = ORTools::CpModel.new
+
+    x = model.new_int_var(0, 5, "x")
+    y = model.new_int_var(0, 5, "y")
+    model.add(x == 3)
+    model.add(y == 5)
+
+    min_var = model.new_int_var(0, 5, "min")
+    max_var = model.new_int_var(0, 5, "max")
+    prod = model.new_int_var(0, 25, "prod")
+
+    model.add_min_equality(min_var, [x, y])
+    model.add_max_equality(max_var, [x, y])
+    model.add_multiplication_equality(prod, [x, y])
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :optimal, status
+    assert_equal 3, solver.value(min_var)
+    assert_equal 5, solver.value(max_var)
+    assert_equal 15, solver.value(prod)
+  end
+
   def test_automaton_consecutive_limit
     model = ORTools::CpModel.new
 
@@ -327,5 +645,25 @@ class ConstraintTest < Minitest::Test
       end
     end
     assert ok, "Found more than #{limit} consecutive 1s: #{values.inspect}"
+  end
+
+  def test_automaton_rejects_invalid_sequence
+    model = ORTools::CpModel.new
+
+    vars = 3.times.map { |i| model.new_int_var(0, 1, "transition_#{i}") }
+    transitions = [
+      [0, 0, 1],
+      [1, 0, 1],
+      [1, 1, 2]
+    ]
+
+    model.add_automaton(vars, 0, [2], transitions)
+
+    # Force an invalid sequence: first transition is 1, which has no outgoing edge from state 0.
+    model.add(vars[0] == 1)
+
+    solver = ORTools::CpSolver.new
+    status = solver.solve(model)
+    assert_equal :infeasible, status
   end
 end

--- a/test/solution_printer_test.rb
+++ b/test/solution_printer_test.rb
@@ -65,7 +65,7 @@ class SolutionPrinterTest < Minitest::Test
     solver.parameters.num_workers = 4
     solution_printer = ORTools::ObjectiveSolutionPrinter.new
 
-    stdout, _ = capture_io do
+    capture_io do
       solver.solve(model, solution_printer)
     end
     assert solution_printer.solution_count >= 1


### PR DESCRIPTION
## Summary
- Expose the remaining CP-SAT constraint types (automaton, circuit/multiple circuit, reservoir, cumulative, no-overlap 2D, etc.) plus helper builders (fixed-size intervals, element/variable element, min/max/div/mul equalities, hints/assumptions, etc.) through the C++ extension so the Ruby API can build richer models.
- Rework the CP-SAT solver callback integration to run OR-Tools on a worker thread without holding the Ruby GVL, queue responses thread-safely, and invoke Ruby callbacks on the main thread—making multi-worker solve callbacks safe and adding the missing parameter accessors.
- Add end-to-end tests that cover the newly exposed constraints and behaviors (cardinality, element, circuit/multiple-circuit, reservoir, cumulative, no-overlap 2D, automaton). Also add a regression test ensuring solution callbacks work with multiple workers.