### PR TITLE
Reorganize platform detection and support Alpine amd64

### DIFF
--- a/ext/or-tools/vendor.rb
+++ b/ext/or-tools/vendor.rb
@@ -4,67 +4,54 @@ require "net/http"
 require "tmpdir"
 
 version = "9.15.6755"
+# Lookup table based on the OS, Version, ARM?
+platforms = {
+  ["arch",   nil,     false] => ["or-tools_amd64_archlinux_cpp_v#{version}.tar.gz",    "5505079f7b2a6d9379ba6ae446a3a639226d455ef1cfa32d2d23ffc4566e3a4b"],
+  ["darwin", nil,     false] => ["or-tools_x86_64_macOS-26.2_cpp_v#{version}.tar.gz",  "d2d36482727520ccaff979eba16f53e6b2cabf40b6fd1126e4d3b34fad2fe851"],
+  ["darwin", nil,     true]  => ["or-tools_arm64_macOS-26.2_cpp_v#{version}.tar.gz",   "de0400a45939a66ee13cd8360c230e830fc5e03a6ed5a8a8b60f58a39e4a67bc"],
+  ["debian", "11",    false] => ["or-tools_amd64_debian-11_cpp_v#{version}.tar.gz",    "c6c4341ff8f9aae3e77f161ca8ea3bb0d22f35ff696596fd11ec51c5da6bd4f7"],
+  ["debian", "12",    false] => ["or-tools_amd64_debian-12_cpp_v#{version}.tar.gz",    "b2c9870c8778eeb26c98742402da17da039c058fca7eca87be5c90832b04153c"],
+  ["ubuntu", "20.04", false] => ["or-tools_amd64_ubuntu-20.04_cpp_v#{version}.tar.gz", "cfe5068b0fe4bafff916ab1b75670b341e80571c8cfd8b647dfe3e97a233e836"],
+  ["ubuntu", "22.04", false] => ["or-tools_amd64_ubuntu-22.04_cpp_v#{version}.tar.gz", "0b30114d7c05f0596286bf3ef8d02adcf5f45be3b39273490e6bb74a2a9bd1ea"],
+  ["ubuntu", "24.04", false] => ["or-tools_amd64_ubuntu-24.04_cpp_v#{version}.tar.gz", "6f389320672cee00b78aacefb2bde33fef0bb988c3b2735573b9fffd1047fbda"],
+}
 
-arch = RbConfig::CONFIG["host_cpu"]
-arm = arch.match?(/arm|aarch64/i)
+def detect_os
+  arm = RbConfig::CONFIG["host_cpu"].match?(/arm|aarch64/i)
 
-if RbConfig::CONFIG["host_os"].match?(/darwin/i)
-  if arm
-    filename = "or-tools_arm64_macOS-26.2_cpp_v#{version}.tar.gz"
-    checksum = "de0400a45939a66ee13cd8360c230e830fc5e03a6ed5a8a8b60f58a39e4a67bc"
-  else
-    filename = "or-tools_x86_64_macOS-26.2_cpp_v#{version}.tar.gz"
-    checksum = "d2d36482727520ccaff979eba16f53e6b2cabf40b6fd1126e4d3b34fad2fe851"
-  end
-else
-  # try /etc/os-release with fallback to /usr/lib/os-release
+  return ['Windows', nil, arm] if Gem.win_platform?
+  return ["darwin", nil, arm] if RbConfig::CONFIG["host_os"].match?(/darwin/i)
+
+  # Try /etc/os-release with fallback to /usr/lib/os-release
   # https://www.freedesktop.org/software/systemd/man/os-release.html
   os_filename = File.exist?("/etc/os-release") ? "/etc/os-release" : "/usr/lib/os-release"
 
   # for safety, parse rather than source
   os_info = File.readlines(os_filename, chomp: true).to_h { |v| v.split("=", 2) }.transform_values { |v| v.delete_prefix('"').delete_suffix('"') } rescue {}
 
-  os = os_info["ID"]
-  os_version = os_info["VERSION_ID"]
+  [os_info["ID"], os_info["VERSION_ID"], arm]
+end
 
-  if os == "ubuntu" && os_version == "24.04" && !arm
-    filename = "or-tools_amd64_ubuntu-24.04_cpp_v#{version}.tar.gz"
-    checksum = "6f389320672cee00b78aacefb2bde33fef0bb988c3b2735573b9fffd1047fbda"
-  elsif os == "ubuntu" && os_version == "22.04" && !arm
-    filename = "or-tools_amd64_ubuntu-22.04_cpp_v#{version}.tar.gz"
-    checksum = "0b30114d7c05f0596286bf3ef8d02adcf5f45be3b39273490e6bb74a2a9bd1ea"
-  elsif os == "ubuntu" && os_version == "20.04" && !arm
-    filename = "or-tools_amd64_ubuntu-20.04_cpp_v#{version}.tar.gz"
-    checksum = "cfe5068b0fe4bafff916ab1b75670b341e80571c8cfd8b647dfe3e97a233e836"
-  elsif os == "debian" && os_version == "12" && !arm
-    filename = "or-tools_amd64_debian-12_cpp_v#{version}.tar.gz"
-    checksum = "b2c9870c8778eeb26c98742402da17da039c058fca7eca87be5c90832b04153c"
-  elsif os == "debian" && os_version == "11" && !arm
-    filename = "or-tools_amd64_debian-11_cpp_v#{version}.tar.gz"
-    checksum = "c6c4341ff8f9aae3e77f161ca8ea3bb0d22f35ff696596fd11ec51c5da6bd4f7"
-  elsif os == "arch" && !arm
-    filename = "or-tools_amd64_archlinux_cpp_v#{version}.tar.gz"
-    checksum = "5505079f7b2a6d9379ba6ae446a3a639226d455ef1cfa32d2d23ffc4566e3a4b"
-  else
-    platform =
-      if Gem.win_platform?
-        "Windows"
-      elsif os || os_version
-        "#{os} #{os_version} #{arch}"
-      else
-        "Unknown"
-      end
+os, os_version, arm = detect_os
+filename, checksum = platforms[[os, os_version, arm]] || platforms[[os, nil, arm]]
 
-    # there is a binary download for Windows
-    # however, it's compiled with Visual Studio rather than MinGW (which RubyInstaller uses)
-    raise <<~MSG
-      Binary installation not available for this platform: #{platform}
+unless filename
+  platform =
+    if os || os_version
+      "#{os} #{os_version} #{RbConfig::CONFIG["host_cpu"]}"
+    else
+      "Unknown"
+    end
 
-      Build the OR-Tools C++ library from source, then run:
-      bundle config build.or-tools --with-or-tools-dir=/path/to/or-tools
+  # there is a binary download for Windows
+  # however, it's compiled with Visual Studio rather than MinGW (which RubyInstaller uses)
+  raise <<~MSG
+    Binary installation not available for this platform: #{platform}
 
-    MSG
-  end
+    Build the OR-Tools C++ library from source, then run:
+    bundle config build.or-tools --with-or-tools-dir=/path/to/or-tools
+
+  MSG
 end
 
 short_version = version.split(".").first(2).join(".")

--- a/ext/or-tools/vendor.rb
+++ b/ext/or-tools/vendor.rb
@@ -6,6 +6,7 @@ require "tmpdir"
 version = "9.15.6755"
 # Lookup table based on the OS, Version, ARM?
 platforms = {
+  ["alpine", nil,     false] => ["or-tools_amd64_alpine-edge_cpp_v#{version}.tar.gz",  "f7324bb1be49dae7187441834d24e6f73eb7f93c13ea37d8b5fe45e9698ede2f"],
   ["arch",   nil,     false] => ["or-tools_amd64_archlinux_cpp_v#{version}.tar.gz",    "5505079f7b2a6d9379ba6ae446a3a639226d455ef1cfa32d2d23ffc4566e3a4b"],
   ["darwin", nil,     false] => ["or-tools_x86_64_macOS-26.2_cpp_v#{version}.tar.gz",  "d2d36482727520ccaff979eba16f53e6b2cabf40b6fd1126e4d3b34fad2fe851"],
   ["darwin", nil,     true]  => ["or-tools_arm64_macOS-26.2_cpp_v#{version}.tar.gz",   "de0400a45939a66ee13cd8360c230e830fc5e03a6ed5a8a8b60f58a39e4a67bc"],


### PR DESCRIPTION
Replace the if/elsif chain for supported OS/distro resolution with a declarative platforms hash, making it easy to see at a glance which operating systems and distributions are supported:
The second commit, adds support for Alpine on amd64.

- macOS (x86_64, ARM)
- Debian 11, 12 (amd64)
- Ubuntu 20.04, 22.04, 24.04 (amd64)
- Arch Linux (amd64)
- Alpine (amd64) 🆕

---

I'm really happy I found your gem because it made it easy to use or-tools in my Rails app. Small hiccup, the app runs in Docker on Alpine Linux. There's official support for amd64, and I'm working on the arm64 support. I'd like to add support for them in the near future.