### PR TITLE
Release GVL when solving and enable multithreaded solving without blocking the main ruby thread

### DIFF
--- a/ext/or-tools/constraint.cpp
+++ b/ext/or-tools/constraint.cpp
@@ -6,6 +6,8 @@
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
+#include "gvl_callback.hpp"
+
 using operations_research::Domain;
 using operations_research::sat::BoolVar;
 using operations_research::sat::Constraint;
@@ -425,26 +427,16 @@ void init_constraint(Rice::Module& m) {
     .define_method(
       "_solve",
       [](Object self, CpModelBuilder& model, SatParameters& parameters, Object callback) {
-        Model m;
+        Model solver_model;
+        solver_model.Add(NewSatParameters(parameters));
 
-        if (!callback.is_nil()) {
-          // use a single worker since Ruby code cannot be run in a non-Ruby thread
-          parameters.set_num_search_workers(1);
+        const operations_research::sat::CpModelProto proto = model.Build();
 
-          m.Add(NewFeasibleSolutionObserver(
-            [&callback](const CpSolverResponse& r) {
-              if (!ruby_native_thread_p()) {
-                throw std::runtime_error{"Non-Ruby thread"};
-              }
-
-              callback.call("response=", r);
-              callback.call("on_solution_callback");
-            })
-          );
+        if (callback.is_nil()) {
+          return ortools_ruby_solve_cp_model_no_callback(proto, solver_model);
         }
 
-        m.Add(NewSatParameters(parameters));
-        return SolveCpModel(model.Build(), &m);
+        return ortools_ruby_solve_cp_model_with_callback(proto, solver_model, callback);
       })
     .define_method(
       "_solution_integer_value",

--- a/ext/or-tools/gvl_callback.hpp
+++ b/ext/or-tools/gvl_callback.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <ortools/sat/cp_model.h>
+#include <rice/rice.hpp>
+#include <ruby/thread.h>
+
+namespace {
+
+struct ORToolsRubyCallbackQueue {
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::deque<operations_research::sat::CpSolverResponse> responses;
+  bool solver_finished = false;
+  bool has_final_response = false;
+  operations_research::sat::CpSolverResponse final_response;
+};
+
+struct ORToolsRubyWaitForEventArgs {
+  ORToolsRubyCallbackQueue* queue;
+  bool has_response = false;
+  operations_research::sat::CpSolverResponse response;
+};
+
+static void* ortools_ruby_wait_for_event_without_gvl(void* ptr) {
+  auto* args = static_cast<ORToolsRubyWaitForEventArgs*>(ptr);
+  std::unique_lock<std::mutex> lock(args->queue->mutex);
+  args->queue->cv.wait(lock, [args]() {
+    return args->queue->solver_finished || !args->queue->responses.empty();
+  });
+
+  if (!args->queue->responses.empty()) {
+    args->response = args->queue->responses.front();
+    args->queue->responses.pop_front();
+    args->has_response = true;
+  } else {
+    args->has_response = false;
+  }
+
+  return nullptr;
+}
+
+static operations_research::sat::CpSolverResponse ortools_ruby_solve_cp_model_without_gvl(
+  const operations_research::sat::CpModelProto* proto,
+  operations_research::sat::Model* model
+) {
+  return operations_research::sat::SolveCpModel(*proto, model);
+}
+
+static operations_research::sat::CpSolverResponse ortools_ruby_solve_cp_model_no_callback(
+  const operations_research::sat::CpModelProto& proto,
+  operations_research::sat::Model& solver_model
+) {
+  return Rice::detail::no_gvl(
+    &ortools_ruby_solve_cp_model_without_gvl,
+    &proto,
+    &solver_model
+  );
+}
+
+static operations_research::sat::CpSolverResponse ortools_ruby_solve_cp_model_with_callback(
+  const operations_research::sat::CpModelProto& proto,
+  operations_research::sat::Model& solver_model,
+  Rice::Object callback
+) {
+  VALUE rb_cb = callback.value();
+  rb_gc_register_address(&rb_cb);
+
+  auto callback_queue = std::make_shared<ORToolsRubyCallbackQueue>();
+
+  solver_model.Add(operations_research::sat::NewFeasibleSolutionObserver(
+    [callback_queue](const operations_research::sat::CpSolverResponse& r) {
+      std::lock_guard<std::mutex> lock(callback_queue->mutex);
+      callback_queue->responses.push_back(r);
+      callback_queue->cv.notify_one();
+    })
+  );
+
+  std::thread solver_thread([&proto, &solver_model, callback_queue]() {
+    auto response = ortools_ruby_solve_cp_model_without_gvl(&proto, &solver_model);
+    {
+      std::lock_guard<std::mutex> lock(callback_queue->mutex);
+      callback_queue->final_response = response;
+      callback_queue->has_final_response = true;
+      callback_queue->solver_finished = true;
+    }
+    callback_queue->cv.notify_all();
+  });
+
+  operations_research::sat::CpSolverResponse final_response;
+
+  try {
+    Rice::Object rb_callback(rb_cb);
+
+    while (true) {
+      ORToolsRubyWaitForEventArgs wait_args{callback_queue.get()};
+      rb_thread_call_without_gvl(
+        ortools_ruby_wait_for_event_without_gvl,
+        &wait_args,
+        RUBY_UBF_IO,
+        nullptr
+      );
+
+      if (wait_args.has_response) {
+        Rice::Data_Object<operations_research::sat::CpSolverResponse> rb_response(
+          new operations_research::sat::CpSolverResponse(wait_args.response)
+        );
+        rb_callback.call("response=", rb_response);
+        rb_callback.call("on_solution_callback");
+      }
+
+      bool done = false;
+      {
+        std::lock_guard<std::mutex> lock(callback_queue->mutex);
+        done = callback_queue->solver_finished && callback_queue->responses.empty();
+      }
+
+      if (done && !wait_args.has_response) {
+        break;
+      }
+    }
+  } catch (...) {
+    solver_thread.join();
+    rb_gc_unregister_address(&rb_cb);
+    throw;
+  }
+
+  solver_thread.join();
+
+  {
+    std::lock_guard<std::mutex> lock(callback_queue->mutex);
+    if (callback_queue->has_final_response) {
+      final_response = callback_queue->final_response;
+    }
+  }
+
+  rb_gc_unregister_address(&rb_cb);
+  return final_response;
+}
+
+} // namespace

--- a/test/solution_printer_test.rb
+++ b/test/solution_printer_test.rb
@@ -54,4 +54,23 @@ class SolutionPrinterTest < Minitest::Test
     assert_equal 15, solution_printer.solution_count
     assert_match "Solution 14", stdout
   end
+
+  def test_objective_solution_printer_with_multiple_workers
+    model = ORTools::CpModel.new
+    x = model.new_int_var(-7, 7, "x")
+    y = model.new_int_var(0, 7, "y")
+    model.add_max_equality(y, [x, model.new_constant(0)])
+
+    solver = ORTools::CpSolver.new
+    solver.parameters.num_workers = 4
+    solution_printer = ORTools::ObjectiveSolutionPrinter.new
+
+    capture_io do
+      solver.solve(model, solution_printer)
+    end
+    assert solution_printer.solution_count >= 1
+
+    GC.start
+    assert_equal 0, solution_printer.objective_value
+  end
 end


### PR DESCRIPTION
Extract out the GVL work from this PR: https://github.com/ankane/or-tools-ruby/pull/77

## Summary

This PR makes CP-SAT solution callbacks safe to use when the solver runs with multiple workers by ensuring Ruby callback code is executed on the Ruby thread, while the solver runs without holding the GVL.

## Changes

- Updates `ext/or-tools/constraint.cpp` to route solving through new helper functions and to support callbacks without forcing single-threaded search.
- Adds `ext/or-tools/gvl_callback.hpp`, implementing a queue-based bridge: the solver runs in a background thread, intermediate `CpSolverResponse`s are queued, and Ruby `on_solution_callback` is invoked from the Ruby thread.
- Extends `test/solution_printer_test.rb` with a test that runs `ObjectiveSolutionPrinter` with `num_workers = 4` and verifies callback behavior remains valid after GC.